### PR TITLE
Don't allow disabled options to be de-selected

### DIFF
--- a/js/jquery.uix.multiselect.js
+++ b/js/jquery.uix.multiselect.js
@@ -1210,7 +1210,7 @@
         },
 
         setSelected: function(eData, selected, silent) {
-            if (eData.optionElement.attr('disabled') && selected) {
+            if (eData.optionElement.attr('disabled')) {
                 return;
             }
 


### PR DESCRIPTION
Current behaviour: 
If a disabled item is initially selected, you can still deselect it. Once deselected a disabled item can't be selected again.
New behaviour:
A disabled item can't change status.
