### PR TITLE
Select percentage width bug fix

### DIFF
--- a/js/jquery.uix.multiselect.js
+++ b/js/jquery.uix.multiselect.js
@@ -71,7 +71,12 @@
             this.optionGroupIndex = 1;
             this._setLocale(this.options.locale);
 
-            this.element.addClass('uix-multiselect-original');
+            this.element
+                .css({
+                    'width': this.element.outerWidth(),
+                    'height': this.element.outerHeight()
+                })
+                .addClass('uix-multiselect-original');
             this._elementWrapper = $('<div></div>').addClass('uix-multiselect ui-widget')
                 .css({
                     'width': this.element.outerWidth(),


### PR DESCRIPTION
When original select has its width set to percentage value, the widget is resized to window size if no parent elements have 'relative' position. That is because original select position is set to absolute and when 'resize' method is being called, original select is resized according to its absolute position.
While Issue #41 has an opposite problem, this fix is a temporary descision until better sizing method developed.
