### PR TITLE
Fix for filtering selected elements

### DIFF
--- a/js/jquery.uix.multiselect.js
+++ b/js/jquery.uix.multiselect.js
@@ -1191,7 +1191,7 @@
                 if ((!eData.selected || filterSelected) && (eData.filtered != filtered)) {
                     eData.listElement[filtered ? 'hide' : 'show']();
                     eData.filtered = filtered;
-                } else if (eData.selected) {
+                } else if (eData.selected && !filterSelected) {
                     eData.filtered = false;
                 }
             }


### PR DESCRIPTION
There is a issue where when you filter selected items. If the selected item was filtered and you change the filter where that same item is still filtered it won't enter the first if statement and go into the second if statement. (This shouldn't happen because it's saying that the element hasn't been filtered)
