### PR TITLE
Fix for Filtering

### DIFF
--- a/js/jquery.uix.multiselect.js
+++ b/js/jquery.uix.multiselect.js
@@ -1192,7 +1192,7 @@
                     eData.listElement[filtered ? 'hide' : 'show']();
                     eData.filtered = filtered;
                 } else if (eData.selected) {
-                    eData.filtered = false;
+                    eData.filtered = filtered;
                 }
             }
 


### PR DESCRIPTION
There is two issues. 

One where when you filter selected items. If the selected item was filtered and you change the filter where that same item is still filtered it won't enter the first if statement and go into the second if statement. (The second if statement will always make the selected items say that it isn't filtered when it should just update to say if it has been filtered or not) So this change will always update the eData.filtered to the correct value.

The other issue is when NOT filtering selected items if you drag a selected item onto the available list it will not filter the item. This change will have it's filtered property always being updated so that when you append the element onto the available list the list is able to filter this item properly.
